### PR TITLE
Modificari 27.11.2020 - separare porturi, implementare timeout, probleme la receiver

### DIFF
--- a/receiver.py
+++ b/receiver.py
@@ -1,14 +1,16 @@
 import socket
 import datetime
-from package import package, frame
+import select
+from package import *
 
 S_HOST = '127.0.0.1' # adresa sender-ului
 R_HOST = '127.0.0.2' # adresa receiver-ului
-PORT = 50000
+S_PORT = 50000
+R_PORT = 50010
 
-# adresa sender-ului, respectiv receptorului
-S_ADDR = (S_HOST, PORT)
-R_ADDR = (R_HOST, PORT)
+# adresa sender-ului, respectiv receiver-ului
+S_ADDR = (S_HOST, S_PORT)
+R_ADDR = (R_HOST, R_PORT)
 
 window_size = 10 # dimensiunea ferestrei glisante a receptorului
 failure_chance = 0.1 # sansa ca un pachet sa nu ajunga la receptor ( 0.1 = 10% )
@@ -31,45 +33,55 @@ for i in range(window_size):
 	sentence_pcs.append('')
 
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-s.bind(R_ADDR)
+s.bind(('0.0.0.0', R_PORT))
 
 while True:
 	try:
-		# asteapta pana receptioneaza un pachet data_snd cu adresa addr_snd, venit de la sender
-		data_snd, addr_snd = s.recvfrom(1024)
+		# caut un raspuns in buffer-ul de receptie
+		response, _, _ = select.select([s], [], [], 1)
+		if response:
+			# asteapta pana receptioneaza un pachet data_snd cu adresa addr_snd, venit de la sender
+			data_snd, addr_snd = s.recvfrom(1024)
 
-		if addr_snd == S_ADDR:
-			pack_s.load_pack(data_snd)
-			with open('receiver.log', 'a') as f_log:
-				f_log.write(f'Received - Package: {pack_s.type} -- {pack_s.info} -- {pack_s.seq_num} Address: {addr_snd} Date: {datetime.datetime.now()}\n')
-
-
-			# daca pachetul contine un fragment de propozitie( type = info )
-			# si secventa de unde provine nu depaseste numarul maxim de secvente curent(seq_num)
-			if pack_s.type == 'info' and pack_s.seq_num < seq_num:
-				# este preluat numarul de secventa din primul frame din fereastra
-				seq_begin = window_r[0].seq_num
-
-				# folosind variabila de mai sus, se va determina pozitia din fereastra unde va fi pusa informatia, iar acolo este confirmat ca a fost primit
-				window_r[pack_s.seq_num - seq_begin].info = pack_s.info
-				window_r[pack_s.seq_num - seq_begin].is_ack = True
-				sentence_pcs[pack_s.seq_num] = pack_s.info
-
-				pack_r.seq_num = pack_s.seq_num
-				dumped_pack = pack_r.dump_pack()
-				s.sendto(dumped_pack, S_ADDR)
-
+			# daca adresa primita coincide cu adresa sender-ului
+			if addr_snd == S_ADDR:
+				# se incarca pachetul primit de la sender spre analizare
+				pack_s.load_pack(data_snd)
+				# fisier log pentru verificarea transmisiei/receptiei in receiver
 				with open('receiver.log', 'a') as f_log:
-					f_log.write(f'Sent - Package: {pack_r.type} -- {pack_r.info} -- {pack_r.seq_num} Address: {S_ADDR} Date: {datetime.datetime.now()}\n')
+					f_log.write(f'Received - Package: {pack_s.type} -- {pack_s.info} -- {pack_s.seq_num} Address: {addr_snd} Date: {datetime.datetime.now()}\n')
 
-			while window_r[0].is_ack:
-				window_r.pop(0)
-				window_r.append(frame('', False, seq_num))
-				sentence_pcs.append('')
-				seq_num += 1
 
-		if window_r[0].info == '':
-			break
+				# daca pachetul contine un fragment de propozitie( type = info )
+				# si secventa de unde provine nu depaseste numarul maxim de secvente curent(seq_num)
+				if pack_s.type == 'info' and pack_s.seq_num < seq_num:
+					# este preluat numarul de secventa din primul frame din fereastra
+					seq_begin = window_r[0].seq_num
+
+					# folosind variabila de mai sus, se va determina pozitia din fereastra unde va fi pusa informatia, iar acolo este confirmat ca a fost primit
+					window_r[pack_s.seq_num - seq_begin].info = pack_s.info
+					window_r[pack_s.seq_num - seq_begin].is_ack = True
+					sentence_pcs[pack_s.seq_num] = pack_s.info
+
+					# odata pusa informatia in vectorul de parti de date, se transmite catre sender un pachet de ack la secventa de unde a venit partea
+					pack_r.seq_num = pack_s.seq_num
+					dumped_pack_rcv = pack_r.dump_pack()
+					s.sendto(dumped_pack_rcv, S_ADDR)
+
+					with open('receiver.log', 'a') as f_log:
+						f_log.write(f'Sent - Package: {pack_r.type} -- {pack_r.info} -- {pack_r.seq_num} Address: {S_ADDR} Date: {datetime.datetime.now()}\n')
+
+				# Scoatem din fereastra, incepand de la prima pozitie, toate frame-urile confirmate pana cand gasim un frame inca in asteptare
+				# De asemenea, adaugam in locul lor, la finalul ferestrei, un nou frame cu informatie goala
+				while window_r[0].is_ack:
+					window_r.pop(0)
+					window_r.append(frame('', False, seq_num))
+					sentence_pcs.append('')
+					seq_num += 1
+
+				# Oprim receptionarea pachetelor cand primul frame din fereastra nu are nici o informatie(adica am primit toate pachete de la receiver)
+				if window_r[0].info == '':
+					break
 
 	except KeyboardInterrupt:
 		break

--- a/sender.py
+++ b/sender.py
@@ -1,26 +1,28 @@
 import socket
-from package import package, frame
 import datetime
 import threading
 import select
 import time
+from package import *
 
 
-def reception_fct(timeout):
+def timeout_send(pack_s):
+	data_snd = pack_s.dump_pack()
+	s.sendto(data_snd, R_ADDR)
+
+	with open('sender.log', 'a') as f_log:
+		f_log.write(f'Sent - Package: {pack_s.type} -- {pack_s.info} -- {pack_s.seq_num} Address: {R_ADDR} Date: {datetime.datetime.now()}\n')
+
+def reception_fct():
 	global pack_r
 	global window_s
 	global seq_num
 	global pack_s
 
-	# setam timpul de timeout al primirii unui raspuns la pachet
-	contor = timeout
-
 	while True:
+		# caut un raspuns in buffer-ul de receptie
 		response, _, _ = select.select([s], [], [], 1)
-		if not response:
-			#contor -= 1 # timeout
-			pass
-		else:
+		if response:
 			info_rcv, addr_rcv = s.recvfrom(1024)
 			if addr_rcv == R_HOST:
 				pack_r.load_pack(info_rcv)
@@ -33,19 +35,7 @@ def reception_fct(timeout):
 
 					# folosind variabila de mai sus, se va determina pozitia din fereastra unde va fi pusa informatia
 					window_s[pack_r.seq_num - seq_begin].is_ack = pack_s.info
-
-				while window_s[0].is_ack:
-					window_s.drop(0)
-					if len(prop) != 0:
-						if len(prop) >= pack_size:
-							window_s.append(frame(prop[:pack_size], False, seq_num))
-						else:
-							window_s.append(frame(prop, False, seq_num))
-					seq_num += 1
-			break
-
-		# daca a expirat timpul de timeout
-		if contor == 0:
+		if len(window_s) == 0:
 			break
 
 
@@ -54,11 +44,12 @@ def reception_fct(timeout):
 
 S_HOST = '127.0.0.1' # adresa sender-ului
 R_HOST = '127.0.0.2' # adresa receiver-ului
-PORT = 50000
+S_PORT = 50000
+R_PORT = 50001
 
 # adresa sender-ului, respectiv receptorului
-S_ADDR = (S_HOST, PORT)
-R_ADDR = (R_HOST, PORT)
+S_ADDR = (S_HOST, S_PORT)
+R_ADDR = (R_HOST, R_PORT)
 
 timeout = 5000 # timpul, in milisecunde, in care socket-ul asteapta un pachet
 end_to_end_delay = 4000 # timpul, in milisecunde, intre momentele de transmisie a pachetelor
@@ -72,11 +63,15 @@ sentence =  '' # sir de caractere
 seq_num = 0	# pozitia sirurului de caractere din vectorul de propozitii
 # util in buffer, pentru a simula glisarea ferestrei
 
-receive_threads = [] # vector de thread-uri pentru fiecare element din buffer
-# este utilizat pentru numerotarea timeout-ului cand se trimite un pachet cu informatii
+timeout_threads = [] # vector de thread-uri pentru fiecare element din buffer
+# un thread de aici este utilizat pentru trimiterea unui nou pachet cu informatii cand timer-ul timeout expira
+
 for i in range(window_size):
-	thread = threading.Thread(target = reception_fct, args = (timeout, ))
-	receive_threads.append(thread)
+	timeout_thread = threading.Timer(timeout/1000, timeout_send, args = (0, )) # un template de Timer, pentru a ne asigura la prima iteratie
+																			# a trimiterii pachetelor, sa fie primit cum trebuie Timer-ul
+	timeout_threads.append(timeout_thread)
+
+receive_thread = threading.Thread(target = reception_fct) # thread de receptie a pachetelor de ack pentru sender
 
 # citim un sir de propozitii
 sentence = input('Propozitia :')
@@ -98,7 +93,7 @@ while len(window_s) != window_size and len(prop) != 0 :
 		seq_num += 1
 		prop = prop.strip(prop[:pack_size])
 
-		# umplem buffer-ul pana cand toate propozitia este pusa sau buffer-ul este plin
+		# umplem fereastra pana cand aceasta este plina sau toata propozitia este pusa
 		while len(window_s) != window_size and len(prop) != 0:
 			if len(prop) >= pack_size:
 				window_s.append(frame(prop[:pack_size], False, seq_num))
@@ -107,9 +102,6 @@ while len(window_s) != window_size and len(prop) != 0 :
 				window_s.append(frame(prop, False, seq_num))
 				prop = ''
 			seq_num += 1
-			
-		# ce a mai ramas din propozitie este pus in locul propozitiei initiale, pentru a fi pus din nou cand se va goli buffer-ul
-		# si/sau pentru a fi eliminat din sirul de propozitii(daca toate propozitia a incaput in buffer)
 
 	# daca propozitia incape complet in zona de buffer 
 	else:
@@ -120,33 +112,73 @@ while len(window_s) != window_size and len(prop) != 0 :
 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
 # fiind portul principal de transmitere, va fi conectat la un PORT, la adresa ip S_HOST
-s.bind(S_ADDR)
+s.bind(('0.0.0.0', S_PORT))
 
-#while True:
-try:
-	for i in range(len(window_s)):
-		pack_s.info = window_s[i].info
-		pack_s.seq_num = window_s[i].seq_num
-		dumped_pack = pack_s.dump_pack()
-		s.sendto(dumped_pack, R_ADDR)
+while True:
+	try:
+		# De fiecare data in fereastra se trimite pentru fiecare frame un pachet de tip info, ce contine atat informatia stocata in frame,
+		# cat si numarul de secventa a ferestrei.
+		for i in range(len(window_s)):
+			# Daca nu exista nici un Timer activ pe frame sau cel precedent a expirat, atunci se creeaza un Timer pe baza pachetului 
+			# info pentru frame in care, daca expira timpul timeout(durata maxima in care asteapta un pachet ack de la receiver), se va trimite din nou pachetul
+			if not timeout_threads[i].is_alive() and window_s[i].is_ack == False:			
+				pack_s.info = window_s[i].info
+				pack_s.seq_num = window_s[i].seq_num
+				timeout_threads[i] = threading.Timer(timeout/1000, timeout_send, args = (pack_s, ))
+				dumped_pack_snd = pack_s.dump_pack()
+				s.sendto(dumped_pack_snd, R_ADDR)
 
-		# fisier log pentru verificarea transmisiei/receptiei pachetelor pentru sender
-		with open('sender.log', 'a') as f_log:
-			f_log.write(f'Sent - Package: {pack_s.type} -- {pack_s.info} -- {pack_s.seq_num} Address: {R_ADDR} Date: {datetime.datetime.now()}\n')
-		thread = threading.Thread()
+				# fisier log pentru verificarea transmisiei/receptiei pachetelor pentru sender
+				with open('sender.log', 'a') as f_log:
+					f_log.write(f'Sent - Package: {pack_s.type} -- {pack_s.info} -- {pack_s.seq_num} Address: {R_ADDR} Date: {datetime.datetime.now()}\n')
+				timeout_threads[i].start()
 
-		receive_threads[i].start()
-		receive_threads[i].join()
+			# Daca frame-ul a primit confirmarea ca a fost primit de receiver, oprim thread-ul de timeout doar daca acesta inca lucreaza
+			if window_s[i].is_ack == True and timeout_threads[i].is_alive():
+				timeout_threads[i].cancel()
+
+		# Scoatem din fereastra, incepand de la prima pozitie, toate frame-urile confirmate pana cand gasim un frame inca in asteptare
+		while len(window_s) != 0 and window_s[0].is_ack == True:
+			window_s.pop(0)
+		
+		# umplem fereastra cu frame-uri ce contin bucati ramase din informatia prop
+		while len(window_s) != window_size and len(prop) != 0 :
+			#daca propozitia nu poate incapea complet intr-o zona din buffer
+			if len(prop) > pack_size:
+				# punem cate o parte din propozitie intr-un frame cat ne permite zona de buffer(maxim pack_size octeti pe zona)
+				window_s.append(frame(prop[:pack_size], False, seq_num)) 
+				# Frame-ul consta intr-un sir de caractere, un boolean ce va determina daca frame-ul a fost primit in receiver si 
+				# pozitia in secventa de trimitere a sirurilor spre receiver 
+				seq_num += 1
+				prop = prop.strip(prop[:pack_size])
+
+				# umplem fereastra pana cand toate propozitia este pusa sau buffer-ul este plin
+				while len(window_s) != window_size and len(prop) != 0:
+					if len(prop) >= pack_size:
+						window_s.append(frame(prop[:pack_size], False, seq_num))
+						prop = prop.strip(prop[:pack_size])
+					else:
+						window_s.append(frame(prop, False, seq_num))
+						prop = ''
+					seq_num += 1
+
+				# daca propozitia incape complet in zona de buffer 
+				else:
+					window_s.append(prop)
+					prop = ''
 
 			
+		# cand nu mai este nimic de trimis in receiver(fereastra este goala), sunt asteptate sa se inchida thread-urile
+		if len(window_s) == 0:
+			for x in timeout_threads:
+				if x.is_alive():
+					x.join()
+			receive_thread.join()
+			break
 
-	if len(window_s) == 0:
-		pass
 
-
-except KeyboardInterrupt:
-	#break
-	pass
+	except KeyboardInterrupt:
+		break
 
 s.close()
 


### PR DESCRIPTION
Varianta aproape completa a sender-ului si receiver-ului in programul de baza. Am aplicat obiecte de tip Timer pentru implementarea timeout-ului. De asemenea, am pus sender-ul si receiver-ul in 2 porturi separate. Sender-ul trimite pachetele catre receiver,dar receiver-ul nu le primeste. Inca nu am gasit cauza, dar probabil este o chichita la bind-ul de la socheturi. Am atasat fisier-ul log(si singurul care a fost generat), cu ce s-a intamplat la una din teste.
[sender.log](https://github.com/Chihalau-Adrian-Ioan/Proiect-RC/files/5608718/sender.log)
